### PR TITLE
Remove private posts from the front end status query

### DIFF
--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -309,7 +309,7 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 			$query->set( 'post__not_in', array_merge( $excluded_ids, $this->get_hidden_downloads() ) );
 
 			// Logged in users also see private posts, so explicitly set the post status to publish only.
-			if ( is_user_logged_in() ) {
+			if ( is_user_logged_in() && ! empty( $query->query_vars['post_type'] ) && 'download' === $query->query_vars['post_type'] ) {
 				$statuses = isset( $query->query_vars['post_status'] ) ? $query->query_vars['post_status'] : array( 'publish' );
 				if ( is_array( $statuses ) ) {
 					$statuses = array_diff( $statuses, array( 'private' ) );

--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -296,7 +296,7 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 					return;
 				}
 			}
-			
+
 			// Allow the /wp/v2/downloads endpoint to show the product to admins
 			if ( defined( 'REST_REQUEST' ) && REST_REQUEST && current_user_can( 'edit_posts' ) ) {
 				return;
@@ -307,6 +307,16 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 			$excluded_ids = isset( $query->query_vars['post__not_in'] ) ? $query->query_vars['post__not_in'] : array();
 			// make sure we're merging with existing post__not_in so we do not override it
 			$query->set( 'post__not_in', array_merge( $excluded_ids, $this->get_hidden_downloads() ) );
+
+			// Logged in users also see private posts, so explicitly set the post status to publish only.
+			if ( is_user_logged_in() ) {
+				$statuses = isset( $query->query_vars['post_status'] ) ? $query->query_vars['post_status'] : array( 'publish' );
+				if ( is_array( $statuses ) ) {
+					$statuses = array_diff( $statuses, array( 'private' ) );
+				}
+
+				$query->set( 'post_status', $statuses );
+			}
 		}
 
 		/**

--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -240,6 +240,7 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 						'meta_key'       => '_edd_hide_download',
 						'posts_per_page' => - 1,
 						'fields'         => 'ids',
+						'no_found_rows'  => true,
 					)
 				);
 

--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -245,7 +245,7 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 
 				$hidden_downloads = $downloads->posts;
 			}
-			$hidden_downloads = is_array( $hidden_downloads ) ? array_unique( $hidden_downloads ) : $array();
+			$hidden_downloads = is_array( $hidden_downloads ) ? array_unique( $hidden_downloads ) : array();
 
 			set_transient( 'edd_hd_ids', $hidden_downloads );
 

--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -307,16 +307,6 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 			$excluded_ids = isset( $query->query_vars['post__not_in'] ) ? $query->query_vars['post__not_in'] : array();
 			// make sure we're merging with existing post__not_in so we do not override it
 			$query->set( 'post__not_in', array_merge( $excluded_ids, $this->get_hidden_downloads() ) );
-
-			// Logged in users also see private posts, so explicitly set the post status to publish only.
-			if ( is_user_logged_in() && ! empty( $query->query_vars['post_type'] ) && 'download' === $query->query_vars['post_type'] ) {
-				$statuses = isset( $query->query_vars['post_status'] ) ? $query->query_vars['post_status'] : array( 'publish' );
-				if ( is_array( $statuses ) ) {
-					$statuses = array_diff( $statuses, array( 'private' ) );
-				}
-
-				$query->set( 'post_status', $statuses );
-			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes #10

Proposed changes:
1. If a user is logged in and the query is for the `download` post type, check if the `post_status` has been set for a query.
2. If not, set the status to an array of just published posts.
3. If the `post_status` parameter is an array, remove `private` from the array.