### PR TITLE
Resolve PHP warning/fatal error

### DIFF
--- a/edd-hide-download.php
+++ b/edd-hide-download.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'EDD_Hide_Download' ) ) {
 		 * @since  1.2
 		 * @var    array
 		 */
-		private $hidden_downloads;
+		private $hidden_downloads = array();
 
 		/**
 		 * Current version number.


### PR DESCRIPTION
This PR will resolve the following PHP error right after the plugin is first activated, or when the transients are manually deleted running PHP7.4+: `array_merge(): Expected parameter 2 to be an array, null given in /wp-content/plugins/edd-hide-download/edd-hide-download.php on line 355`

This errors occurs when `WP_Query()` is run to determine the hidden download IDs inside `EDD_Hide_Download::query_hidden_downloads()`. During the database lookup the `pre_get_posts` hook is triggered and `EDD_Hide_Download::pre_get_posts()` is run, which in turn calls `EDD_Hide_Download::get_hidden_downloads()`. As the plugin is in the middle of determining the hidden downloads, `null` is passed to `array_merge` and the error is triggered.

The simple fix is to set the default value of the `$hidden_downloads` property to an array.